### PR TITLE
Use correct node module name in instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ See [example/](./example/) for an example of usage.
 First, install the npm module.
 
 ```sh
-npm install --save-dev webpack-hot-middleware
+npm install --save-dev koa-webpack-hot-middleware
 ```
 
 Next, enable hot reloading in your webpack config:


### PR DESCRIPTION
Pretty sure that was a mistake in the README. Thanks for the plugin. Trying to set it up as I type this :)
